### PR TITLE
Removed adding Null points to polyline

### DIFF
--- a/ScatterDraw/ScatterDraw.cpp
+++ b/ScatterDraw/ScatterDraw.cpp
@@ -1669,9 +1669,7 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 		for (double x = xmin; x <= xmax; x++) {
 			double xx = data.x(x);
 			double yy = data.y(x);
-			if (!IsNum(xx) || !IsNum(yy))
-				points << Null;
-			else
+			if (IsNum(xx) && IsNum(yy))
 				points << Point(ScaleX(xx), ScaleY(yy));
 		}
 	} else if (data.IsExplicit()) {
@@ -1680,9 +1678,7 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 		double dx = (xmax - xmin)/plotW;
 		for (double xx = xmin; xx < xmax; xx += dx) {
 			double yy = data.f(xx);
-			if (!IsNum(yy))
-				points << Null;
-			else
+			if (IsNum(yy))
 				points << Point(ScaleX(xx), ScaleY(yy));
 		}
 	} else {
@@ -1734,9 +1730,7 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 				npix++;
 				int ix = ScaleX(xx);
 				int iMax, iMin;
-				if (!IsNum(yy)) 
-					points << Null;							
-				else {
+				if (IsNum(yy)) {
 					iMax = ScaleY(maxY);
 					iMin = ScaleY(minY);
 					points << Point(ix, iMax);
@@ -1749,9 +1743,7 @@ Vector<Pointf> ScatterDraw::DataAddPoints(DataSource& data, bool primaryY, bool 
 				double xx = data.x(i);
 				double yy = data.y(i);
 				++i;
-				if (!IsNum(xx) || !IsNum(yy)) 
-					points << Null;
-				else
+				if (IsNum(xx) && IsNum(yy)) 
 					points << Point(ScaleX(xx), ScaleY(yy));
 			}
 		}


### PR DESCRIPTION
If an explicit function is zoomed out so that the arguments are out of function's domain, Null points were added to a polyline. For a data range view it added a point in minus infinity which produced a strange picture.
So adding Null points was removed from the code as I cannot see any place in the Scatter code were it is actually used.